### PR TITLE
Make width adapt window size.

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -17,7 +17,7 @@ class Content {
       if (t.isString(content)) {
         const table = new Table({ column: ansi.format(content) }, {
           padding: defaultPadding,
-          maxWidth: 80
+          maxWidth: process.stdout.columns || 80
         })
         return table.renderLines()
 
@@ -26,7 +26,7 @@ class Content {
         const rows = content.map(string => ({ column: ansi.format(string) }))
         const table = new Table(rows, {
           padding: defaultPadding,
-          maxWidth: 80
+          maxWidth: process.stdout.columns || 80
         })
         return table.renderLines()
 

--- a/lib/option-list.js
+++ b/lib/option-list.js
@@ -38,7 +38,7 @@ class OptionList extends Section {
 
     const table = new Table(columns, {
       padding: { left: '  ', right: ' ' },
-      columns: [{ name: 'option', noWrap: true }, { name: 'description', maxWidth: 80 }]
+      columns: [{ name: 'option', noWrap: true }, { name: 'description', maxWidth: process.stdout.columns || 80 }]
     })
     this.add(table.renderLines())
 


### PR DESCRIPTION
I have found that the usage is always displayed with 80 characters width. Hence I slightly adjusted your code, so that it makes use of the actual width of the terminal - or falls back to 80 characters, if the width of the terminal can not be retrieved.

I hope you like this idea 😊 