### PR TITLE
Make option-list width configurable

### DIFF
--- a/example/simple-width.js
+++ b/example/simple-width.js
@@ -10,6 +10,11 @@ const usage = commandLineUsage([
         { col: 'Generates something [italic]{very} important. This is a rather long, but ultimately inconsequential description intended solely to demonstrate description appearance. ' }
       ]
     }
+  },
+  {
+    header: 'Options',
+    optionList: optionDefinitions,
+    options: { maxWidth: 40 }
   }
 ])
 

--- a/lib/option-list.js
+++ b/lib/option-list.js
@@ -40,7 +40,7 @@ class OptionList extends Section {
       padding: { left: '  ', right: ' ' },
       columns: [
         { name: 'option', noWrap: true },
-        { name: 'description', maxWidth: 80 }
+        { name: 'description', maxWidth: (data.options && data.options.maxWidth) || 80 }
       ]
     })
     this.add(table.renderLines())


### PR DESCRIPTION
Reads a maxWidth option off of the data object passed to optionlist if one is present. The default value is 80. This resembles the API for content.

- make maxWidth of option-list configurable
- add options to simple-width example

Resolves #13 