### PR TITLE
Omits the content fields that are not strings

### DIFF
--- a/lib/chalk-format.js
+++ b/lib/chalk-format.js
@@ -5,7 +5,7 @@ function format (str) {
 }
 
 function chalkFormat (str) {
-  if (str) {
+  if (str && (typeof str === "string" || str instanceof String)) {
     str = str.replace(/`/g, '\\`')
     return format(str)
   } else {


### PR DESCRIPTION
A lot of times command-line-usage is used in conjunction with command-line-args to process the arguments. 

In order to parse the command line args, a similar structure to the one used by the command-line-usage options must be used. P.ex: `{name: "help", alias: "h", type: Boolean, description: "Display this usage guide"},`. 

In command-line-usage the options uses something like this: `{name: "help", alias: "h", description: "Display this usage guide"}`.

Notice that the only difference is that the first one includes a type property that doesn't have a string value.

This pull request allows to use the same definition on both cases, reusing code and error sources when both packages are used in conjunction. It does so just by checking that the options value is a string and if not, a blank string is returned.