### PR TITLE
feature: support conditional chalk usage via options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 tmp
 out
+node_modules
+.idea
+.vscode

--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@
  * @returns {string}
  * @alias module:command-line-usage
  */
-function commandLineUsage (sections) {
+function commandLineUsage (sections, options) {
+  options = options || {
+    useChalk: true
+  }
   const arrayify = require('array-back')
   sections = arrayify(sections)
   if (sections.length) {
@@ -16,9 +19,9 @@ function commandLineUsage (sections) {
     const ContentSection = require('./lib/section/content')
     const output = sections.map(section => {
       if (section.optionList) {
-        return new OptionList(section)
+        return new OptionList(section, options)
       } else {
-        return new ContentSection(section)
+        return new ContentSection(section, options)
       }
     })
     return '\n' + output.join('\n')

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * @module command-line-usage
  */
 
+const arrayify = require('array-back')
+
 /**
  * Generates a usage guide suitable for a command-line app.
  * @param {Section|Section[]} - One or more section objects ({@link module:command-line-usage~content} or {@link module:command-line-usage~optionList}).
@@ -12,7 +14,6 @@ function commandLineUsage (sections, options) {
   options = options || {
     useChalk: true
   }
-  const arrayify = require('array-back')
   sections = arrayify(sections)
   if (sections.length) {
     const OptionList = require('./lib/section/option-list')

--- a/lib/chalk-format.js
+++ b/lib/chalk-format.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk')
 
 function chalkFormat (str, options) {
+  options = options || { useChalk : true }
   if (str) {
     str = str.replace(/`/g, '\\`')
     return options.useChalk

--- a/lib/chalk-format.js
+++ b/lib/chalk-format.js
@@ -1,8 +1,11 @@
-function chalkFormat (str) {
+const chalk = require('chalk')
+
+function chalkFormat (str, options) {
   if (str) {
     str = str.replace(/`/g, '\\`')
-    const chalk = require('chalk')
-    return chalk(Object.assign([], { raw: [str] }))
+    return options.useChalk
+      ? chalk(Object.assign([], { raw: [str] }))
+      : str
   } else {
     return ''
   }

--- a/lib/section.js
+++ b/lib/section.js
@@ -1,11 +1,17 @@
+const chalk = require('chalk')
+const os = require('os')
+const arrayify = require('array-back')
+
 class Section {
-  constructor () {
+  constructor (options) {
+    this.options = options || {
+      useChalk: true
+    }
     this.lines = []
   }
 
   add (lines) {
     if (lines) {
-      const arrayify = require('array-back')
       arrayify(lines).forEach(line => this.lines.push(line))
     } else {
       this.lines.push('')
@@ -13,14 +19,15 @@ class Section {
   }
 
   toString () {
-    const os = require('os')
     return this.lines.join(os.EOL)
   }
 
   header (text) {
-    const chalk = require('chalk')
     if (text) {
-      this.add(chalk.underline.bold(text))
+      const formatted = this.options.useChalk
+        ? chalk.underline.bold(text)
+        : text
+      this.add(formatted)
       this.add()
     }
   }

--- a/lib/section/content.js
+++ b/lib/section/content.js
@@ -4,9 +4,9 @@ const Table = require('table-layout')
 const chalkFormat = require('../chalk-format')
 
 class ContentSection extends Section {
-  constructor (section) {
-    super()
-    this.header(section.header)
+  constructor (section, options) {
+    super(options)
+    this.header(section.header, options)
 
     if (section.content) {
       /* add content without indentation or wrapping */

--- a/lib/section/content.js
+++ b/lib/section/content.js
@@ -12,10 +12,10 @@ class ContentSection extends Section {
       /* add content without indentation or wrapping */
       if (section.raw) {
         const arrayify = require('array-back')
-        const content = arrayify(section.content).map(line => chalkFormat(line))
+        const content = arrayify(section.content).map(line => chalkFormat(line, options))
         this.add(content)
       } else {
-        this.add(getContentLines(section.content))
+        this.add(getContentLines(section.content, options))
       }
 
       this.add()
@@ -23,13 +23,13 @@ class ContentSection extends Section {
   }
 }
 
-function getContentLines (content) {
+function getContentLines (content, options) {
   const defaultPadding = { left: '  ', right: ' ' }
 
   if (content) {
     /* string content */
     if (t.isString(content)) {
-      const table = new Table({ column: chalkFormat(content) }, {
+      const table = new Table({ column: chalkFormat(content, options) }, {
         padding: defaultPadding,
         maxWidth: 80
       })
@@ -37,7 +37,7 @@ function getContentLines (content) {
 
     /* array of strings */
     } else if (Array.isArray(content) && content.every(t.isString)) {
-      const rows = content.map(string => ({ column: chalkFormat(string) }))
+      const rows = content.map(string => ({ column: chalkFormat(string, options) }))
       const table = new Table(rows, {
         padding: defaultPadding,
         maxWidth: 80
@@ -73,7 +73,7 @@ function getContentLines (content) {
       }
 
       const table = new Table(
-        content.data.map(row => ansiFormatRow(row)),
+        content.data.map(row => ansiFormatRow(row, options)),
         options
       )
       return table.renderLines()
@@ -84,9 +84,9 @@ function getContentLines (content) {
   }
 }
 
-function ansiFormatRow (row) {
+function ansiFormatRow (row, options) {
   for (const key in row) {
-    row[key] = chalkFormat(row[key])
+    row[key] = chalkFormat(row[key], options)
   }
   return row
 }

--- a/lib/section/content.js
+++ b/lib/section/content.js
@@ -1,6 +1,7 @@
 const Section = require('../section')
 const t = require('typical')
 const Table = require('table-layout')
+const arrayify = require('array-back')
 const chalkFormat = require('../chalk-format')
 
 class ContentSection extends Section {
@@ -11,7 +12,6 @@ class ContentSection extends Section {
     if (section.content) {
       /* add content without indentation or wrapping */
       if (section.raw) {
-        const arrayify = require('array-back')
         const content = arrayify(section.content).map(line => chalkFormat(line, options))
         this.add(content)
       } else {

--- a/lib/section/option-list.js
+++ b/lib/section/option-list.js
@@ -5,7 +5,7 @@ const t = require('typical')
 const arrayify = require('array-back')
 
 class OptionList extends Section {
-  constructor (data) {
+  constructor (data, options) {
     super()
     let definitions = arrayify(data.optionList)
     const hide = arrayify(data.hide)
@@ -30,8 +30,8 @@ class OptionList extends Section {
 
     const rows = definitions.map(def => {
       return {
-        option: getOptionNames(def, data.reverseNameOrder),
-        description: chalk(def.description)
+        option: getOptionNames(def, data.reverseNameOrder, options),
+        description: options.useChalk ? chalk(def.description) : def.description
       }
     })
 
@@ -49,31 +49,50 @@ class OptionList extends Section {
   }
 }
 
-function getOptionNames (definition, reverseNameOrder) {
+function getOptionNames (definition, reverseNameOrder, options) {
   let type = definition.type ? definition.type.name.toLowerCase() : 'string'
   const multiple = (definition.multiple || definition.lazyMultiple) ? '[]' : ''
   if (type) {
-    type = type === 'boolean' ? '' : `{underline ${type}${multiple}}`
+    if (type === 'boolean') {
+      type = ''
+    } else {
+      type = options.useChalk
+          ? `{underline ${type}${multiple}}`
+          : `${type}${multiple}`
+    }
   }
-  type = chalk(definition.typeLabel || type)
+  type = options.useChalk
+      ? chalk(definition.typeLabel || type)
+      : definition.typeLabel || type
 
   let result = ''
   if (definition.alias) {
     if (definition.name) {
       if (reverseNameOrder) {
-        result = chalk(`{bold --${definition.name}}, {bold -${definition.alias}} ${type}`)
+        result = options.useChalk
+          ? chalk(`{bold --${definition.name}}, {bold -${definition.alias}} ${type}`)
+          : `--${definition.name}, -${definition.alias} ${type}`
       } else {
-        result = chalk(`{bold -${definition.alias}}, {bold --${definition.name}} ${type}`)
+        result = options.useChalk
+          ? chalk(`{bold -${definition.alias}}, {bold --${definition.name}} ${type}`)
+          : `-${definition.alias}, --${definition.name} ${type}`
       }
     } else {
       if (reverseNameOrder) {
-        result = chalk(`{bold -${definition.alias}} ${type}`)
+        result = options.useChalk
+            ? chalk(`{bold -${definition.alias}} ${type}`)
+            : `${definition.alias} ${type}`
       } else {
-        result = chalk(`{bold -${definition.alias}} ${type}`)
+        result = options.useChalk
+          ? chalk(`{bold -${definition.alias}} ${type}`)
+          : `-${definition.alias} ${type}`
+
       }
     }
   } else {
-    result = chalk(`{bold --${definition.name}} ${type}`)
+    result = options.useChalk
+      ? chalk(`{bold --${definition.name}} ${type}`)
+      : `--${definition.name} ${type}`
   }
   return result
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "command-line-usage",
-  "version": "6.1.3",
+  "name": "@viglucci/command-line-usage",
+  "version": "6.2.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "command-line-usage",
-      "version": "6.1.3",
+      "name": "@viglucci/command-line-usage",
+      "version": "6.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@viglucci/command-line-usage",
+  "name": "command-line-usage",
   "author": "Lloyd Brookes <75pound@gmail.com>",
   "contributors": ["Kevin Viglucci <kviglucci@gmail.com>"],
-  "version": "6.2.0-alpha.0",
+  "version": "6.2.0",
   "description": "Generates command-line usage information",
-  "repository": "https://github.com/viglucci/command-line-usage",
+  "repository": "https://github.com/75lb/command-line-usage",
   "license": "MIT",
   "files": [
     "lib/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "command-line-usage",
+  "name": "@viglucci/command-line-usage",
   "author": "Lloyd Brookes <75pound@gmail.com>",
-  "version": "6.1.3",
+  "contributors": ["Kevin Viglucci <kviglucci@gmail.com>"],
+  "version": "6.2.0-alpha.0",
   "description": "Generates command-line usage information",
-  "repository": "https://github.com/75lb/command-line-usage",
+  "repository": "https://github.com/viglucci/command-line-usage",
   "license": "MIT",
   "files": [
     "lib/**/*.js",

--- a/test/section-content.js
+++ b/test/section-content.js
@@ -1,6 +1,7 @@
 const Tom = require('test-runner').Tom
 const commandLineUsage = require('../')
 const a = require('assert')
+const EOL = require('os').EOL
 
 const tom = module.exports = new Tom('section-content')
 

--- a/test/section-content.js
+++ b/test/section-content.js
@@ -1,7 +1,6 @@
 const Tom = require('test-runner').Tom
 const commandLineUsage = require('../')
 const a = require('assert')
-const EOL = require('os').EOL
 
 const tom = module.exports = new Tom('section-content')
 


### PR DESCRIPTION
We are attempting to use this library in a context where formatting and adding color through `chalk` doesn't make sense. This change introduces support for conditional usage of `chalk` through an additional options object.

## Usage

Generate usage without colors or formatting:

```js
commandLineUsage(sections, { useChalk: false });
```

## Other

If you are amenable to this change, I can also add related tests, documentation, etc..