### PR TITLE
chore: upgrade table-layout dep from 4.1.0 to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "array-back": "^6.2.2",
     "chalk-template": "^0.4.0",
-    "table-layout": "^4.1.0",
+    "table-layout": "^4.1.1",
     "typical": "^7.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`table-layout@4.1.0` still uses the `deep-merge@1.1.1`, which has a critical vulnerability.

Upgrade to `table-layout@4.1.1`, which no longer uses that dependency.